### PR TITLE
更改epub文件下载路径，更改测试文件下载路径

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,7 @@
 .DS_Store
 
 download
-1587
-1973
-718
-353
+downloader/test
 
 build
 

--- a/downloader/download_chapter_test.go
+++ b/downloader/download_chapter_test.go
@@ -19,7 +19,7 @@ func TestDownloadChapter(t *testing.T) {
 	}
 	err := scraper.GetChapterContent(chapter)
 	require.NoError(t, err)
-	err = DownloadChapter(chapter, "第一卷")
+	err = DownloadChapter(chapter, "./test/第一卷")
 	require.NoError(t, err)
 	chapterImage := &scraper.Chapter{
 		Index: 1,
@@ -28,7 +28,7 @@ func TestDownloadChapter(t *testing.T) {
 	}
 	err = scraper.GetChapterContent(chapterImage)
 	require.NoError(t, err)
-	err = DownloadChapter(chapterImage, "第二卷")
+	err = DownloadChapter(chapterImage, "./test/第二卷")
 	require.NoError(t, err)
 
 }

--- a/downloader/download_image_test.go
+++ b/downloader/download_image_test.go
@@ -10,6 +10,6 @@ func TestDownloadImage(t *testing.T) {
 	/*
 		http://pic.wenku8.com/pictures/1/1973/75978/90772.jpg http://pic.wenku8.com/pictures/1/1973/75978/90773.jpg http://pic.wenku8.com/pictures/1/1973/75978/90774.jpg http://pic.wenku8.com/pictures/1/1973/75978/90775.jpg http://pic.wenku8.com/pictures/1/1973/75978/90776.jpg http://pic.wenku8.com/pictures/1/1973/75978/90777.jpg http://pic.wenku8.com/pictures/1/1973/75978/90778.jpg http://pic.wenku8.com/pictures/1/1973/75978/90779.jpg http://pic.wenku8.com/pictures/1/1973/75978/90780.jpg http://pic.wenku8.com/pictures/1/1973/75978/90781.jpg http://pic.wenku8.com/pictures/1/1973/75978/90782.jpg http://pic.wenku8.com/pictures/1/1973/75978/90783.jpg http://pic.wenku8.com/pictures/1/1973/75978/90784.jpg http://pic.wenku8.com/pictures/1/1973/75978/90785.jpg http://pic.wenku8.com/pictures/1/1973/75978/90786.jpg http://pic.wenku8.com/pictures/1/1973/75978/90787.jpg http://pic.wenku8.com/pictures/1/1973/75978/90788.jpg http://pic.wenku8.com/pictures/1/1973/75978/90789.jpg http://pic.wenku8.com/pictures/1/1973/75978/90790.jpg http://pic.wenku8.com/pictures/1/1973/75978/90791.jpg http://pic.wenku8.com/pictures/1/1973/75978/90792.jpg
 	*/
-	err := DownloadImage("http://pic.wenku8.com/pictures/1/1973/75978/90774.jpg", "./插图/")
+	err := DownloadImage("http://pic.wenku8.com/pictures/1/1973/75978/90774.jpg", "./test/插图/")
 	require.NoError(t, err)
 }

--- a/downloader/download_volume_test.go
+++ b/downloader/download_volume_test.go
@@ -11,6 +11,6 @@ func TestDownloadVolume(t *testing.T) {
 	volumeArray, err := scraper.GetNovelVolumeArray("https://www.wenku8.net/novel/1/1973/index.htm")
 	require.NoError(t, err)
 	require.NotEmpty(t, volumeArray)
-	err = DownloadVolume(volumeArray[0], "./", true)
+	err = DownloadVolume(volumeArray[0], "./test", true)
 	require.NoError(t, err)
 }

--- a/prompt/download.go
+++ b/prompt/download.go
@@ -18,7 +18,7 @@ import (
 )
 
 func download(novelId int) error {
-	downloadPath := strconv.Itoa(novelId)
+	downloadPath := "download/" + strconv.Itoa(novelId)
 	if err := util.CheckDir(downloadPath); err != nil {
 		return fmt.Errorf("创建目录失败: %e", err)
 	}


### PR DESCRIPTION
将epub默认目录从根目录移至download目录，将测试文件从downloader移至downloader/test下，并在.gitignore中增加